### PR TITLE
Allow for a variable endpoint and custom client headers

### DIFF
--- a/gql/cli.py
+++ b/gql/cli.py
@@ -40,6 +40,7 @@ def cli():
     pass
 
 
+# Just check that line number of error updates
 @cli.command()
 @click.option('--schema', prompt=SCHEMA_PROMPT, default='http://localhost:4000')
 @click.option('--endpoint', prompt=ENDPOINT_PROMPT, default='same as schema')

--- a/gql/cli.py
+++ b/gql/cli.py
@@ -43,7 +43,7 @@ def cli():
 @cli.command()
 @click.option('--schema', prompt=SCHEMA_PROMPT, default='http://localhost:4000')
 @click.option('--endpoint', prompt=ENDPOINT_PROMPT, default='same as schema')
-@click.option('--endpoint_type', prompt=TYPE_PROMPT, default='static', type=click.Choice(['static', 'variable'], case_sensitive=False))
+@click.option('--endpoint_type', prompt=TYPE_PROMPT, default='static')
 @click.option('--root', prompt=ROOT_PROMPT, default='./src')
 @click.option('-c', '--config', 'config_filename', default=DEFAULT_CONFIG_FNAME, type=click.Path(exists=False))
 def init(schema, endpoint, endpoint_type, root, config_filename):

--- a/gql/cli.py
+++ b/gql/cli.py
@@ -53,7 +53,8 @@ def init(schema, endpoint, root, config_filename):
     config = Config(
         schema=schema,
         endpoint=endpoint,
-        documents=join_paths(root, '**/*.graphql')
+        documents=join_paths(root, '**/*.graphql'),
+        client_headers={}
     )
 
     config.save(config_filename)

--- a/gql/cli.py
+++ b/gql/cli.py
@@ -18,6 +18,12 @@ DEFAULT_CONFIG_FNAME = '.gql.json'
 SCHEMA_PROMPT = click.style('Where is your schema?: ', fg='bright_white') + \
                 click.style('(path or url) ', fg='bright_black', dim=False)
 
+ENDPOINT_PROMPT = click.style('What is the endpoint for the API?: ', fg='bright_white') + \
+                  click.style('(string or variable) ', fg='bright_black', dim=False)
+
+TYPE_PROMPT = click.style('Was the supplied endpoint a string or variable definition?: ', fg='bright_white') + \
+                       click.style('(options: \'static\' or \'variable\') ', fg='bright_black', dim=False)
+
 ROOT_PROMPT = click.style('Whats the root of your project: ', fg='bright_white') + \
               click.style('(path or url) ', fg='bright_black', dim=False)
 
@@ -36,10 +42,11 @@ def cli():
 
 @cli.command()
 @click.option('--schema', prompt=SCHEMA_PROMPT, default='http://localhost:4000')
-@click.option('--endpoint', prompt=SCHEMA_PROMPT, default='same as schema')
+@click.option('--endpoint', prompt=ENDPOINT_PROMPT, default='same as schema')
+@click.option('--endpoint_type', prompt=TYPE_PROMPT, default='static', type=click.Choice(['static', 'variable'], case_sensitive=False)
 @click.option('--root', prompt=ROOT_PROMPT, default='./src')
 @click.option('-c', '--config', 'config_filename', default=DEFAULT_CONFIG_FNAME, type=click.Path(exists=False))
-def init(schema, endpoint, root, config_filename):
+def init(schema, endpoint, endpoint_type, root, config_filename):
     if isfile(config_filename):
         click.confirm(f'{config_filename} already exists. Are you sure you want to continue?', abort=True)
 
@@ -49,6 +56,7 @@ def init(schema, endpoint, root, config_filename):
     config = Config(
         schema=schema,
         endpoint=endpoint,
+        endpoint_type=endpoint_type,
         documents=join_paths(root, '**/*.graphql')
     )
 

--- a/gql/cli.py
+++ b/gql/cli.py
@@ -43,7 +43,7 @@ def cli():
 @cli.command()
 @click.option('--schema', prompt=SCHEMA_PROMPT, default='http://localhost:4000')
 @click.option('--endpoint', prompt=ENDPOINT_PROMPT, default='same as schema')
-@click.option('--endpoint_type', prompt=TYPE_PROMPT, default='static', type=click.Choice(['static', 'variable'], case_sensitive=False)
+@click.option('--endpoint_type', prompt=TYPE_PROMPT, default='static', type=click.Choice(['static', 'variable'], case_sensitive=False))
 @click.option('--root', prompt=ROOT_PROMPT, default='./src')
 @click.option('-c', '--config', 'config_filename', default=DEFAULT_CONFIG_FNAME, type=click.Path(exists=False))
 def init(schema, endpoint, endpoint_type, root, config_filename):

--- a/gql/cli.py
+++ b/gql/cli.py
@@ -19,10 +19,7 @@ SCHEMA_PROMPT = click.style('Where is your schema?: ', fg='bright_white') + \
                 click.style('(path or url) ', fg='bright_black', dim=False)
 
 ENDPOINT_PROMPT = click.style('What is the endpoint for the API?: ', fg='bright_white') + \
-                  click.style('(string or variable) ', fg='bright_black', dim=False)
-
-TYPE_PROMPT = click.style('Was the supplied endpoint a string or variable definition?: ', fg='bright_white') + \
-                       click.style('(options: \'static\' or \'variable\') ', fg='bright_black', dim=False)
+                  click.style('(wrap static strings in single quotes, \'<string>\') ', fg='bright_black', dim=False)
 
 ROOT_PROMPT = click.style('Whats the root of your project: ', fg='bright_white') + \
               click.style('(path or url) ', fg='bright_black', dim=False)
@@ -44,20 +41,18 @@ def cli():
 @cli.command()
 @click.option('--schema', prompt=SCHEMA_PROMPT, default='http://localhost:4000')
 @click.option('--endpoint', prompt=ENDPOINT_PROMPT, default='same as schema')
-@click.option('--endpoint_type', prompt=TYPE_PROMPT, default='static', type=click.Choice(['static', 'variable'], case_sensitive=False))
 @click.option('--root', prompt=ROOT_PROMPT, default='./src')
 @click.option('-c', '--config', 'config_filename', default=DEFAULT_CONFIG_FNAME, type=click.Path(exists=False))
-def init(schema, endpoint, endpoint_type, root, config_filename):
+def init(schema, endpoint, root, config_filename):
     if isfile(config_filename):
         click.confirm(f'{config_filename} already exists. Are you sure you want to continue?', abort=True)
 
     if endpoint == 'same as schema':
-        endpoint = schema
+        endpoint = f"'{schema}'"
 
     config = Config(
         schema=schema,
         endpoint=endpoint,
-        endpoint_type=endpoint_type,
         documents=join_paths(root, '**/*.graphql')
     )
 

--- a/gql/cli.py
+++ b/gql/cli.py
@@ -44,7 +44,7 @@ def cli():
 @cli.command()
 @click.option('--schema', prompt=SCHEMA_PROMPT, default='http://localhost:4000')
 @click.option('--endpoint', prompt=ENDPOINT_PROMPT, default='same as schema')
-@click.option('--endpoint_type', prompt=TYPE_PROMPT, default='static')
+@click.option('--endpoint_type', prompt=TYPE_PROMPT, default='static', type=click.Choice(['static', 'variable'], case_sensitive=False))
 @click.option('--root', prompt=ROOT_PROMPT, default='./src')
 @click.option('-c', '--config', 'config_filename', default=DEFAULT_CONFIG_FNAME, type=click.Path(exists=False))
 def init(schema, endpoint, endpoint_type, root, config_filename):

--- a/gql/config.py
+++ b/gql/config.py
@@ -10,7 +10,6 @@ ConfigT = TypeVar('ConfigT', bound='ConfigT')
 class Config:
     schema: str
     endpoint: str
-    endpoint_type: str
     documents: str
     custom_header: str = ''
 

--- a/gql/config.py
+++ b/gql/config.py
@@ -12,6 +12,7 @@ class Config:
     endpoint: str
     documents: str
     custom_header: str = ''
+    client_headers: dict = {}
 
     @classmethod
     def load(cls: Type[ConfigT], filename: str) -> ConfigT:

--- a/gql/config.py
+++ b/gql/config.py
@@ -10,6 +10,7 @@ ConfigT = TypeVar('ConfigT', bound='ConfigT')
 class Config:
     schema: str
     endpoint: str
+    endpoint_type: str
     documents: str
     custom_header: str = ''
 

--- a/gql/config.py
+++ b/gql/config.py
@@ -1,4 +1,4 @@
-from typing import Type, TypeVar
+from typing import Type, TypeVar, Dict, Any
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
 
@@ -11,8 +11,8 @@ class Config:
     schema: str
     endpoint: str
     documents: str
+    client_headers: Dict[str, Any]
     custom_header: str = ''
-    client_headers: dict = None
 
     @classmethod
     def load(cls: Type[ConfigT], filename: str) -> ConfigT:

--- a/gql/config.py
+++ b/gql/config.py
@@ -12,7 +12,7 @@ class Config:
     endpoint: str
     documents: str
     custom_header: str = ''
-    client_headers: dict = field(default_factory=dict)
+    client_headers: dict = None
 
     @classmethod
     def load(cls: Type[ConfigT], filename: str) -> ConfigT:

--- a/gql/config.py
+++ b/gql/config.py
@@ -10,7 +10,7 @@ ConfigT = TypeVar('ConfigT', bound='ConfigT')
 class Config:
     schema: str
     endpoint: str
-    endpoint_type: str = 'static'
+    endpoint_type: str
     documents: str
     custom_header: str = ''
 

--- a/gql/config.py
+++ b/gql/config.py
@@ -10,7 +10,7 @@ ConfigT = TypeVar('ConfigT', bound='ConfigT')
 class Config:
     schema: str
     endpoint: str
-    endpoint_type: str
+    endpoint_type: str = 'static'
     documents: str
     custom_header: str = ''
 

--- a/gql/config.py
+++ b/gql/config.py
@@ -12,7 +12,7 @@ class Config:
     endpoint: str
     documents: str
     custom_header: str = ''
-    client_headers: dict = field(default_factory=list)
+    client_headers: dict = field(default_factory=dict)
 
     @classmethod
     def load(cls: Type[ConfigT], filename: str) -> ConfigT:

--- a/gql/config.py
+++ b/gql/config.py
@@ -12,7 +12,7 @@ class Config:
     endpoint: str
     documents: str
     custom_header: str = ''
-    client_headers: dict = {}
+    client_headers: dict = field(default_factory=list)
 
     @classmethod
     def load(cls: Type[ConfigT], filename: str) -> ConfigT:

--- a/gql/renderer_dataclasses.py
+++ b/gql/renderer_dataclasses.py
@@ -88,6 +88,11 @@ class DataclassesRenderer:
         buffer.write('')
 
     def __render_operation(self, parsed_query: ParsedQuery, buffer: CodeChunk, parsed_op: ParsedOperation):
+        if self.config.endpoint_type == 'variable':
+            client_endpoint = f"{self.config.endpoint}"
+        else:
+            client_endpoint = f"\'{self.config.endpoint}\'"
+        
         buffer.write('@dataclass_json')
         buffer.write('@dataclass')
         with buffer.write_block(f'class {parsed_op.name}:'):
@@ -116,7 +121,7 @@ class DataclassesRenderer:
 
             buffer.write('@classmethod')
             with buffer.write_block(f'def execute(cls, {vars_args} on_before_callback: Callable[[Mapping[str, str], Mapping[str, str]], None] = None):'):
-                buffer.write(f'client = Client(\'{self.config.endpoint}\')')
+                buffer.write(f'client = Client({client_endpoint})')
                 buffer.write(f'variables = {variables_dict}')
                 buffer.write('response_text = client.call(cls.__QUERY__, variables=variables, on_before_callback=on_before_callback)')
                 buffer.write('return cls.from_json(response_text)')
@@ -125,7 +130,7 @@ class DataclassesRenderer:
 
             buffer.write('@classmethod')
             with buffer.write_block(f'async def execute_async(cls, {vars_args} on_before_callback: Callable[[Mapping[str, str], Mapping[str, str]], None] = None):'):
-                buffer.write(f'client = AsyncIOClient(\'{self.config.endpoint}\')')
+                buffer.write(f'client = AsyncIOClient({client_endpoint})')
                 buffer.write(f'variables = {variables_dict}')
                 buffer.write(f'response_text = await client.call(cls.__QUERY__, variables=variables, on_before_callback=on_before_callback)')
                 buffer.write(f'return cls.from_json(response_text)')

--- a/gql/renderer_dataclasses.py
+++ b/gql/renderer_dataclasses.py
@@ -87,12 +87,7 @@ class DataclassesRenderer:
 
         buffer.write('')
 
-    def __render_operation(self, parsed_query: ParsedQuery, buffer: CodeChunk, parsed_op: ParsedOperation):
-        if self.config.endpoint_type == 'variable':
-            client_endpoint = f"{self.config.endpoint}"
-        else:
-            client_endpoint = f"\'{self.config.endpoint}\'"
-        
+    def __render_operation(self, parsed_query: ParsedQuery, buffer: CodeChunk, parsed_op: ParsedOperation):        
         buffer.write('@dataclass_json')
         buffer.write('@dataclass')
         with buffer.write_block(f'class {parsed_op.name}:'):
@@ -121,7 +116,7 @@ class DataclassesRenderer:
 
             buffer.write('@classmethod')
             with buffer.write_block(f'def execute(cls, {vars_args} on_before_callback: Callable[[Mapping[str, str], Mapping[str, str]], None] = None):'):
-                buffer.write(f'client = Client({client_endpoint})')
+                buffer.write(f'client = Client({self.config.endpoint})')
                 buffer.write(f'variables = {variables_dict}')
                 buffer.write('response_text = client.call(cls.__QUERY__, variables=variables, on_before_callback=on_before_callback)')
                 buffer.write('return cls.from_json(response_text)')
@@ -130,7 +125,7 @@ class DataclassesRenderer:
 
             buffer.write('@classmethod')
             with buffer.write_block(f'async def execute_async(cls, {vars_args} on_before_callback: Callable[[Mapping[str, str], Mapping[str, str]], None] = None):'):
-                buffer.write(f'client = AsyncIOClient({client_endpoint})')
+                buffer.write(f'client = AsyncIOClient({self.config.endpoint})')
                 buffer.write(f'variables = {variables_dict}')
                 buffer.write(f'response_text = await client.call(cls.__QUERY__, variables=variables, on_before_callback=on_before_callback)')
                 buffer.write(f'return cls.from_json(response_text)')

--- a/gql/renderer_dataclasses.py
+++ b/gql/renderer_dataclasses.py
@@ -116,7 +116,7 @@ class DataclassesRenderer:
 
             buffer.write('@classmethod')
             with buffer.write_block(f'def execute(cls, {vars_args} on_before_callback: Callable[[Mapping[str, str], Mapping[str, str]], None] = None):'):
-                buffer.write(f'client = Client({self.config.endpoint})')
+                buffer.write(f'client = Client({self.config.endpoint}, headers={self.config.client_headers})')
                 buffer.write(f'variables = {variables_dict}')
                 buffer.write('response_text = client.call(cls.__QUERY__, variables=variables, on_before_callback=on_before_callback)')
                 buffer.write('return cls.from_json(response_text)')
@@ -125,7 +125,7 @@ class DataclassesRenderer:
 
             buffer.write('@classmethod')
             with buffer.write_block(f'async def execute_async(cls, {vars_args} on_before_callback: Callable[[Mapping[str, str], Mapping[str, str]], None] = None):'):
-                buffer.write(f'client = AsyncIOClient({self.config.endpoint})')
+                buffer.write(f'client = AsyncIOClient({self.config.endpoint}, headers={self.config.client_headers})')
                 buffer.write(f'variables = {variables_dict}')
                 buffer.write(f'response_text = await client.call(cls.__QUERY__, variables=variables, on_before_callback=on_before_callback)')
                 buffer.write(f'return cls.from_json(response_text)')


### PR DESCRIPTION
Changes the functionality of the `gql run` command, and the `config` model to support two use-cases.

The first is the use of a variable to define the client endpoint, rather than a static connection string.

The second is to change the .gql.json created by `gql init` to support a 'client-headers' field, which supports a dict of headers to be added to the client requests. The base gql-core library already supports this behavior, so the change simply passes these client headers to the existing client connections.